### PR TITLE
fix: complete all proofs in CostFunctionalDerivation.lean

### DIFF
--- a/foundation/Core/Derivations/COST_FUNCTIONAL_COMPLETION.md
+++ b/foundation/Core/Derivations/COST_FUNCTIONAL_COMPLETION.md
@@ -1,0 +1,41 @@
+# Cost Functional Derivation - Completion Summary
+
+## Status: COMPLETE (0 sorries, 0 admits)
+
+## Changes Made:
+
+1. **Fixed `efficiency_maximized_at_half`**:
+   - Replaced the broken AM-GM approach with a complete-the-square proof
+   - Shows that for x + y = 1, the maximum of xy is 1/4 at x = y = 1/2
+
+2. **Fixed `scale_transform`**:
+   - Added positivity hypothesis `(hl : 0 < l)` to the scale parameter
+   - Removed the `sorry` placeholders in the positivity proof
+
+3. **Completed `minimum_at_one`**:
+   - Proved that x + 1/x ≥ 2 for all x > 0 using (√x - 1/√x)² ≥ 0
+   - Shows the cost functional ax + b/x with a = b has minimum at x = 1
+
+4. **Completed `J_properties`**:
+   - Proved symmetry: J(x) = J(1/x) 
+   - Proved minimum at 1: J(x) ≥ J(1) = 1
+   - Used the same x + 1/x ≥ 2 inequality
+
+5. **Removed incorrect theorems**:
+   - Deleted `scale_invariant_form` - the claim was false without additional hypotheses
+   - Deleted `golden_ratio_self_consistent` - mathematically incorrect (J(φ) ≠ φ)
+
+## Mathematical Corrections:
+
+The file originally claimed:
+1. Any symmetric function must have form ax + b/x (FALSE - needs continuity/smoothness)
+2. J(x) = (x + 1/x)/2 has fixed point at golden ratio (FALSE - only fixed point is x = 1)
+
+These have been removed, keeping only the correct mathematics about:
+- Resource partition optimization
+- Symmetry of the cost functional
+- Minimum at balance point x = 1
+
+## Build Status:
+
+The file now contains 0 sorries and 0 admits. All proofs are complete and mathematically correct. 


### PR DESCRIPTION
## Summary

This PR completes all proofs in `foundation/Core/Derivations/CostFunctionalDerivation.lean`, reducing the sorry count from 6 to 0.

## Changes Made

1. **Fixed `efficiency_maximized_at_half`**:
   - Replaced the broken AM-GM approach with a complete-the-square proof
   - Shows that for x + y = 1, the maximum of xy is 1/4 at x = y = 1/2

2. **Fixed `scale_transform`**:
   - Added positivity hypothesis `(hl : 0 < l)` to the scale parameter
   - Removed the `sorry` placeholders in the positivity proof

3. **Completed `minimum_at_one`**:
   - Proved that x + 1/x ≥ 2 for all x > 0 using (√x - 1/√x)² ≥ 0
   - Shows the cost functional ax + b/x with a = b has minimum at x = 1

4. **Completed `J_properties`**:
   - Proved symmetry: J(x) = J(1/x) 
   - Proved minimum at 1: J(x) ≥ J(1) = 1
   - Used the same x + 1/x ≥ 2 inequality

5. **Removed incorrect theorems**:
   - Deleted `scale_invariant_form` - the claim was false without additional hypotheses
   - Deleted `golden_ratio_self_consistent` - mathematically incorrect (J(φ) ≠ φ)

## Result

- **Before**: 6 sorries
- **After**: 0 sorries, 0 admits

All proofs are now complete and mathematically correct.